### PR TITLE
Remove for-in loop on array

### DIFF
--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -75,7 +75,7 @@
         },
         enumerize = function (arr) {
             var enums = {};
-            for (var i in arr) {
+            for (var i = 0; i < arr.length; i++) {
                 enums[arr[i].toUpperCase()] = arr[i];
             }
             return enums;


### PR DESCRIPTION
Hey there, I'm trying to load `amplitude-js` into a browser context that also has some third party scripts that we can't control. One such script is modifying the Array prototype and adding additional enumerable properties.

These additional properties are picked up by the for-in loop in `enumerize` and result in the evaluation of `toUpperCase` on potentially non-string values, causing a crash.

Replacing the for-in loop with a counter based for loop would make this safer.