### PR TITLE
SECENG-7700 [security] pinning actions and docker images

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -12,8 +12,8 @@ jobs:
       matrix:
         arch: [amd64, ppc64le]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      - uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
       - name: Run the test
         run: |
           npm install


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions to full-length commit SHAs to prevent supply chain attacks
- Pin Docker base images to digest SHAs where applicable

## Test plan
- [ ] Verify workflows run as expected after pinning